### PR TITLE
Clears SW pended interrupt on exception entry

### DIFF
--- a/zmu_cortex_m/src/core/exception.rs
+++ b/zmu_cortex_m/src/core/exception.rs
@@ -424,10 +424,6 @@ impl ExceptionHandling for Processor {
         if exp.pending {
             exp.pending = false;
             self.pending_exception_count -= 1;
-
-            if let Exception::Interrupt { n } = exception {
-                self.nvic_unpend_interrupt(n);
-            }
         }
     }
 
@@ -435,6 +431,9 @@ impl ExceptionHandling for Processor {
         if exception == Exception::Reset {
             self.reset()
         } else {
+            if let Exception::Interrupt { n } = exception {
+                self.nvic_unpend_interrupt(n);
+            }
             self.push_stack(exception, return_address)?;
             self.exception_taken(exception)
         }
@@ -761,6 +760,32 @@ mod tests {
 
         // Assert
         assert_eq!(processor.get_pending_exception(), None);
+    }
+
+    #[test]
+    fn test_exception_entry_clears_nvic() {
+        // Arrange
+        let mut processor = Processor::new(
+            Some(Box::new(TestWriter {})),
+            &[0; 65536],
+            Box::new(
+                |_semihost_cmd: &SemihostingCommand| -> SemihostingResponse {
+                    panic!("shoud not happen")
+                },
+            ),
+        );
+
+        // Arrange
+        processor.reset().unwrap();
+        processor.nvic_write_iser(0, 1);
+        processor.nvic_write_ispr(0, 1);
+        assert_eq!(processor.nvic_read_ispr(0), 1);
+
+        // Act
+        let _ = processor.exception_entry(Exception::Interrupt { n: 0 }, 0);
+
+        // Assert
+        assert_eq!(processor.nvic_read_ispr(0), 0);
     }
 
 }

--- a/zmu_cortex_m/src/core/exception.rs
+++ b/zmu_cortex_m/src/core/exception.rs
@@ -8,6 +8,7 @@ use crate::core::bits::Bits;
 use crate::core::fault::Fault;
 use crate::core::register::{BaseReg, Ipsr, Reg};
 use crate::core::reset::Reset;
+use crate::peripheral::nvic::NVIC;
 use crate::Processor;
 use crate::ProcessorMode;
 
@@ -423,6 +424,10 @@ impl ExceptionHandling for Processor {
         if exp.pending {
             exp.pending = false;
             self.pending_exception_count -= 1;
+
+            if let Exception::Interrupt { n } = exception {
+                self.nvic_unpend_interrupt(n);
+            }
         }
     }
 

--- a/zmu_cortex_m/src/peripheral/nvic.rs
+++ b/zmu_cortex_m/src/peripheral/nvic.rs
@@ -86,6 +86,11 @@ pub trait NVIC {
     /// 16 bit read from interrupt priority register
     ///
     fn nvic_read_ipr_u16(&self, index: usize) -> u16;
+
+    ///
+    /// Mark interrupt no longer pending in NVIC point of view.
+    ///
+    fn nvic_unpend_interrupt(&mut self, irqn: usize);
 }
 
 trait NVICHelper {
@@ -146,6 +151,12 @@ impl NVIC for Processor {
     fn nvic_write_icer(&mut self, index: usize, value: u32) {
         clear_bits_array(&mut self.nvic_interrupt_enabled, index, value);
         self.nvic_clear_unpended_exceptions(index);
+    }
+
+    fn nvic_unpend_interrupt(&mut self, irqn: usize) {
+        let index = irqn / 32;
+        let bit = irqn % 32;
+        clear_bits_array(&mut self.nvic_interrupt_pending, index, 1 << bit);
     }
 
     fn nvic_read_icer(&self, index: usize) -> u32 {


### PR DESCRIPTION
Otherwise the same interrupt might be re-entered again after it is exited on next nvic operation.

Closes #13