### PR TITLE
Fix execution priority.

### DIFF
--- a/zmu_cortex_m/src/core/exception.rs
+++ b/zmu_cortex_m/src/core/exception.rs
@@ -362,7 +362,7 @@ impl ExceptionHandling for Processor {
                 highestpri = exp.priority;
                 
                 /* 
-                ARMV7-M Arch Reference Manual. Version E. Page B1-157
+                ARMV7-M Arch Reference Manual. Version E. Page B1-527
                 Priority Grouping. The group priority for Reset, NMI 
                 and HardFault are -3, -2 and -1 respectively, regardless
                 of the value of PRIGROUP. Note that we dont check reset because


### PR DESCRIPTION
This commit implements the execution priority as defined in the armv7-m architecture reference manual.

There was a bug where the group priority for reset, nmi and hardfault was not being ignored as specified in the ARMV7-M Arch Reference Manual. Version E. Page B1-157. Here it is defined that the group priority for Hardfault, NMI and Reset is -1, -2 and -3 respectively, regardles of the value of PRIGROUP.

Related: #54 